### PR TITLE
Remove URL modifier

### DIFF
--- a/src/PSIGate/XMLMessenger.php
+++ b/src/PSIGate/XMLMessenger.php
@@ -32,7 +32,7 @@ class XMLMessenger extends Messenger
      */
     public function __construct($host, $storeId, $pass)
     {
-        $this->_url = 'https://'.$host.'/Messenger/XMLMessenger';
+        $this->_url = 'https://' . $host;
         $this->_id = array(
             'StoreID'   => $storeId,
             'Passphrase' => $pass,


### PR DESCRIPTION
API has changed over the years since this was created, the string added to the end of the XML Messenger API URL is no longer needed.

References #1